### PR TITLE
render --> flow blocks as code-block:: none with equal-width lines

### DIFF
--- a/src/rda_python_miscs/pg_rst.py
+++ b/src/rda_python_miscs/pg_rst.py
@@ -873,6 +873,13 @@ class PgRST(PgFile, PgUtil):
          str: RST-formatted table or list content.
       """
       line0 = lines[0]
+      if any('-->' in line for line in lines):
+         max_width = max(len(line) for line in lines)
+         content = ".. code-block:: none\n\n"
+         for line in lines:
+            content += "   " + line.ljust(max_width) + "\n"
+         content += "\n"
+         return content
       ms = re.match(r'^\s+-\s+(.*)', line0)
       if ms:
          content = "* " + self.replace_option_link(ms.group(1), secid, 1)


### PR DESCRIPTION
In create_table, detect when any line in a ptype=1 block contains --> and render the block as a .. code-block:: none directive with each line padded to equal character width using ljust.